### PR TITLE
Upgrade to VS 2019

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,18 @@ bld/
 [Bb]in/
 [Oo]bj/
 
+# Backup & report files from converting an old project file
+# to a newer Visual Studio version. Backup files are not needed,
+# because we have git ;-)
+_UpgradeReport_Files/
+Backup*/
+UpgradeLog*.XML
+UpgradeLog*.htm
+ServiceFabricBackup/
+*.rptproj.bak
+
+# Visual Studio 2015/2017 cache/options directory
+.vs/
 
 # Visual Studio LightSwitch build output
 **/*.HTMLClient/GeneratedArtifacts

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,16 @@ ServiceFabricBackup/
 **/*.Server/ModelManifest.xml
 _Pvt_Extensions
 /source.extension.vsixmanifest
+
+# NuGet Packages
+*.nupkg
+# The packages folder can be ignored because of Package Restore
+**/[Pp]ackages/*
+# except build/, which is used as an MSBuild target.
+!**/[Pp]ackages/build/
+# Uncomment if necessary however generally it will be regenerated when needed
+#!**/[Pp]ackages/repositories.config
+# NuGet v3's project.json files produces more ignorable files
+*.nuget.props
+*.nuget.targets
+

--- a/WakaTime.sln
+++ b/WakaTime.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.25928.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28407.52
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WakaTime", "WakaTime\WakaTime.csproj", "{B05537E5-6B8D-419D-B470-B6FA57BB1C2E}"
 EndProject
@@ -25,5 +25,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5E7E6326-C7AE-4E68-A532-724720A181A2}
 	EndGlobalSection
 EndGlobal

--- a/WakaTime/WakaTime.csproj
+++ b/WakaTime/WakaTime.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">12.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <FileUpgradeFlags>

--- a/WakaTime/source.extension.vsixmanifest-express
+++ b/WakaTime/source.extension.vsixmanifest-express
@@ -12,10 +12,10 @@
 	</Metadata>
 
 	<Installation>
-		<InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.VSWinExpress" />
-		<InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
-		<InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.VPDExpress" />
-		<InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.VWDExpress" />
+		<InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.VSWinExpress" />
+		<InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
+		<InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.VPDExpress" />
+		<InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.VWDExpress" />
 	</Installation>
 
 	<Dependencies>
@@ -28,6 +28,6 @@
 	</Assets>
 
 	<Prerequisites>
-		<Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+		<Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,17.0)" DisplayName="Visual Studio core editor" />
 	</Prerequisites>
 </PackageManifest>

--- a/WakaTime/source.extension.vsixmanifest-express
+++ b/WakaTime/source.extension.vsixmanifest-express
@@ -1,33 +1,33 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Publisher="WakaTime" Version="8.1.0" Id="52d9c3ff-c893-408e-95e4-d7484ec7fa47" Language="en-US" />
-    <DisplayName>WakaTime</DisplayName>
-    <Description xml:space="preserve">Metrics, insights, and time tracking automatically generated from your programming activity.</Description>
-    <MoreInfo>https://github.com/wakatime/visualstudio-wakatime</MoreInfo>
-    <License>LICENSE.txt</License>
-    <Icon>Resources\wakatime-120.png</Icon>
-    <PreviewImage>Resources\Screen-Shot-2016-03-21.png</PreviewImage>
-    <Tags>analytics, metrics, time tracking, productivity, reports</Tags>
-  </Metadata>
+	<Metadata>
+		<Identity Publisher="WakaTime" Version="8.1.0" Id="52d9c3ff-c893-408e-95e4-d7484ec7fa47" Language="en-US" />
+		<DisplayName>WakaTime</DisplayName>
+		<Description xml:space="preserve">Metrics, insights, and time tracking automatically generated from your programming activity.</Description>
+		<MoreInfo>https://github.com/wakatime/visualstudio-wakatime</MoreInfo>
+		<License>..\LICENSE.txt</License>
+		<Icon>Resources\wakatime-120.png</Icon>
+		<PreviewImage>Resources\Screen-Shot-2016-03-21.png</PreviewImage>
+		<Tags>analytics, metrics, time tracking, productivity, reports</Tags>
+	</Metadata>
 
-  <Installation>
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.VSWinExpress" />
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.VPDExpress" />
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.VWDExpress" />
-  </Installation>
+	<Installation>
+		<InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.VSWinExpress" />
+		<InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
+		<InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.VPDExpress" />
+		<InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.VWDExpress" />
+	</Installation>
 
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-    <Dependency Id="Microsoft.VisualStudio.MPF.11.0" DisplayName="Visual Studio MPF 11.0" d:Source="Installed" Version="[11.0]" />
-  </Dependencies>
+	<Dependencies>
+		<Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+		<Dependency Id="Microsoft.VisualStudio.MPF.11.0" DisplayName="Visual Studio MPF 11.0" d:Source="Installed" Version="[11.0]" />
+	</Dependencies>
 
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-  </Assets>
+	<Assets>
+		<Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+	</Assets>
 
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
+	<Prerequisites>
+		<Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+	</Prerequisites>
 </PackageManifest>

--- a/WakaTime/source.extension.vsixmanifest-legacy
+++ b/WakaTime/source.extension.vsixmanifest-legacy
@@ -1,37 +1,37 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Vsix xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2010">
-  <Identifier Id="52d9c3ff-c893-408e-95e4-d7484ec7fa48">
-    <Name>WakaTime (2010)</Name>
-    <Author>WakaTime</Author>
-    <Version>8.1.0</Version>
-    <Description xml:space="preserve">Metrics, insights, and time tracking automatically generated from your programming activity.</Description>
-    <Locale>1033</Locale>
-    <MoreInfoUrl>https://github.com/wakatime/visualstudio-wakatime</MoreInfoUrl>
-    <License>LICENSE.txt</License>
-    <Icon>Resources\wakatime-120.png</Icon>
-    <PreviewImage>Resources\Screen-Shot-2016-03-21.png</PreviewImage>
-    <InstalledByMsi>false</InstalledByMsi>
-    <SupportedProducts>
-      <VisualStudio Version="10.0">
-        <Edition>Ultimate</Edition>
-        <Edition>Premium</Edition>
-        <Edition>Pro</Edition>
-        <Edition>Community</Edition>
-        <Edition>IntegratedShell</Edition>
-        <Edition>Enterprise</Edition>
-        <Edition>VSLS</Edition>
-      </VisualStudio>
-      <IsolatedShell Version="6.0">AtmelStudio</IsolatedShell>
-    </SupportedProducts>
-    <SupportedFrameworkRuntimeEdition MinVersion="4.0" MaxVersion="4.0" />
-  </Identifier>
-  <References>
-    <Reference Id="Microsoft.VisualStudio.MPF" MinVersion="10.0">
-      <Name>Visual Studio MPF</Name>
-    </Reference>
-  </References>
-  <Content>
-    <VsPackage>|%CurrentProject%;PkgdefProjectOutputGroup|</VsPackage>
-    <MefComponent>|%CurrentProject%|</MefComponent>
-  </Content>
+	<Identifier Id="52d9c3ff-c893-408e-95e4-d7484ec7fa48">
+		<Name>WakaTime (2010)</Name>
+		<Author>WakaTime</Author>
+		<Version>8.1.0</Version>
+		<Description xml:space="preserve">Metrics, insights, and time tracking automatically generated from your programming activity.</Description>
+		<Locale>1033</Locale>
+		<MoreInfoUrl>https://github.com/wakatime/visualstudio-wakatime</MoreInfoUrl>
+		<License>..\LICENSE.txt</License>
+		<Icon>Resources\wakatime-120.png</Icon>
+		<PreviewImage>Resources\Screen-Shot-2016-03-21.png</PreviewImage>
+		<InstalledByMsi>false</InstalledByMsi>
+		<SupportedProducts>
+			<VisualStudio Version="10.0">
+				<Edition>Ultimate</Edition>
+				<Edition>Premium</Edition>
+				<Edition>Pro</Edition>
+				<Edition>Community</Edition>
+				<Edition>IntegratedShell</Edition>
+				<Edition>Enterprise</Edition>
+				<Edition>VSLS</Edition>
+			</VisualStudio>
+			<IsolatedShell Version="6.0">AtmelStudio</IsolatedShell>
+		</SupportedProducts>
+		<SupportedFrameworkRuntimeEdition MinVersion="4.0" MaxVersion="4.0" />
+	</Identifier>
+	<References>
+		<Reference Id="Microsoft.VisualStudio.MPF" MinVersion="10.0">
+			<Name>Visual Studio MPF</Name>
+		</Reference>
+	</References>
+	<Content>
+		<VsPackage>|%CurrentProject%;PkgdefProjectOutputGroup|</VsPackage>
+		<MefComponent>|%CurrentProject%|</MefComponent>
+	</Content>
 </Vsix>

--- a/WakaTime/source.extension.vsixmanifest-release
+++ b/WakaTime/source.extension.vsixmanifest-release
@@ -12,13 +12,13 @@
 	</Metadata>
 
 	<Installation>
-		<InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Community" />
-		<InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
-		<InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
-		<InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.IntegratedShell" />
-		<InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Ultimate" />
-		<InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Premium" />
-		<InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.VSLS" />
+		<InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Community" />
+		<InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
+		<InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
+		<InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.IntegratedShell" />
+		<InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Ultimate" />
+		<InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Premium" />
+		<InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.VSLS" />
 	</Installation>
 
 	<Dependencies>
@@ -31,6 +31,6 @@
 	</Assets>
 
 	<Prerequisites>
-		<Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+		<Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,17.0)" DisplayName="Visual Studio core editor" />
 	</Prerequisites>
 </PackageManifest>

--- a/WakaTime/source.extension.vsixmanifest-release
+++ b/WakaTime/source.extension.vsixmanifest-release
@@ -1,36 +1,36 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Publisher="WakaTime" Version="8.1.0" Id="52d9c3ff-c893-408e-95e4-d7484ec7fa47" Language="en-US" />
-    <DisplayName>WakaTime</DisplayName>
-    <Description xml:space="preserve">Metrics, insights, and time tracking automatically generated from your programming activity.</Description>
-    <MoreInfo>https://github.com/wakatime/visualstudio-wakatime</MoreInfo>
-    <License>LICENSE.txt</License>
-    <Icon>Resources\wakatime-120.png</Icon>
-    <PreviewImage>Resources\Screen-Shot-2016-03-21.png</PreviewImage>
-    <Tags>analytics, metrics, time tracking, productivity, reports</Tags>
-  </Metadata>
+	<Metadata>
+		<Identity Publisher="WakaTime" Version="8.1.0" Id="52d9c3ff-c893-408e-95e4-d7484ec7fa47" Language="en-US" />
+		<DisplayName>WakaTime</DisplayName>
+		<Description xml:space="preserve">Metrics, insights, and time tracking automatically generated from your programming activity.</Description>
+		<MoreInfo>https://github.com/wakatime/visualstudio-wakatime</MoreInfo>
+		<License>..\LICENSE.txt</License>
+		<Icon>Resources\wakatime-120.png</Icon>
+		<PreviewImage>Resources\Screen-Shot-2016-03-21.png</PreviewImage>
+		<Tags>analytics, metrics, time tracking, productivity, reports</Tags>
+	</Metadata>
 
-  <Installation>
-    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Community" />
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.IntegratedShell" />
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Ultimate" />
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Premium" />
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.VSLS" />
-  </Installation>
+	<Installation>
+		<InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Community" />
+		<InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
+		<InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
+		<InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.IntegratedShell" />
+		<InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Ultimate" />
+		<InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Premium" />
+		<InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.VSLS" />
+	</Installation>
 
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-    <Dependency Id="Microsoft.VisualStudio.MPF.11.0" DisplayName="Visual Studio MPF 11.0" d:Source="Installed" Version="[11.0]" />
-  </Dependencies>
+	<Dependencies>
+		<Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+		<Dependency Id="Microsoft.VisualStudio.MPF.11.0" DisplayName="Visual Studio MPF 11.0" d:Source="Installed" Version="[11.0]" />
+	</Dependencies>
 
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-  </Assets>
+	<Assets>
+		<Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+	</Assets>
 
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
+	<Prerequisites>
+		<Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+	</Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
- completed .gitignore
  * Backup & report files from converting an old project file
  * Visual Studio 2015/2017 cache/options directory
   * add Package folder to .ignore
- Automatic upgraded of .csproj and .sln by opening the solution in VS2019
- fixed error of no LICENSE.txt which prevented the VSIX to be build
- Upgrade of all the .vsxmanifest as suggested in #83
Tested in debug and "manually" installing the VSIX in debug and release. It seems to work in VS2019 Ent and VS2017 Ent. Probably needs more testing to insure that it works in other VS versions.