### PR TITLE
Adding filter on monitored projects

### DIFF
--- a/WakaTime/WakaTimePackage.cs
+++ b/WakaTime/WakaTimePackage.cs
@@ -55,7 +55,7 @@ namespace WakaTime
 
             // Check if workFolder has been set
             _workFolder = Environment.GetEnvironmentVariable("WAKATIME_WORKFOLDER")?.ToLower();
-            _useWorkFolder = _workFolder != null;
+            _useWorkFolder = !string.IsNullOrEmpty(_workFolder);
 
             // Only perform initialization if async package framework not supported
             if (WakaTime.IsAsyncLoadSupported) return;

--- a/Workfolder.md
+++ b/Workfolder.md
@@ -1,0 +1,5 @@
+# Work folder enhancement
+
+Sometimes it makes sense to monitor activity only on a subset of projects/solutions. For these situations the environemnt variable WAKATIME_WORKFOLDER has been introduced.
+You can specify a path to your working folder, i.e. c:\mywork. Now, only activity on assets in the folder or its descendands gets monitored.
+If you leave the variable undefined or empty, the plugin behaves as before.


### PR DESCRIPTION
# Work folder enhancement

Sometimes it makes sense to monitor activity only on a subset of projects/solutions. For these situations the environment variable WAKATIME_WORKFOLDER has been introduced.
You can specify a path to your working folder, i.e. c:\mywork. Now, only activity on assets in the folder or its descendants gets monitored.
If you leave the variable undefined or empty, the plugin behaves as before.