### PR TITLE
Implemented more detailed and precise activity time measuring

### DIFF
--- a/WakaTime/WakaTime.csproj
+++ b/WakaTime/WakaTime.csproj
@@ -165,8 +165,8 @@
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="WakaTime.Shared.ExtensionUtils, Version=2.0.0.0, Culture=neutral, PublicKeyToken=202d1174b8524eea, processorArchitecture=MSIL">
-      <HintPath>..\packages\WakaTime.Shared.ExtensionUtils.2.0.0\lib\net48\WakaTime.Shared.ExtensionUtils.dll</HintPath>
+    <Reference Include="WakaTime.Shared.ExtensionUtils, Version=2.2.0.0, Culture=neutral, PublicKeyToken=202d1174b8524eea, processorArchitecture=MSIL">
+      <HintPath>..\packages\WakaTime.Shared.ExtensionUtils.2.2.0\lib\net48\WakaTime.Shared.ExtensionUtils.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/WakaTime/WakaTimePackage.cs
+++ b/WakaTime/WakaTimePackage.cs
@@ -33,7 +33,7 @@ namespace WakaTime
         private BuildEvents _buildEvents;
         private TextEditorEvents _textEditorEvents;
 
-        private bool _isBuildRunning = false;
+        private bool _isBuildRunning;
         private string _runningBuildOutput;
 
         public static DTE ObjDte;
@@ -113,8 +113,7 @@ namespace WakaTime
                     mcs.AddCommand(menuItem);
                 }
 
-                // setup event handlers
-                
+                // setup event handlers                
                 _docEvents.DocumentOpened += DocEventsOnDocumentOpened;
                 _docEvents.DocumentSaved += DocEventsOnDocumentSaved;
                 _windowEvents.WindowActivated += WindowEventsOnWindowActivated;
@@ -141,11 +140,14 @@ namespace WakaTime
         {
             try
             {
-                var activity = ObjDte.Debugger.CurrentMode == dbgDebugMode.dbgBreakMode ? HeartbeatCategory.Debugging : HeartbeatCategory.Coding;
-                WakaTime.HandleActivity(document.FullName, false, GetProjectName(), activity); //eventType defaults to "file"
+                var category = ObjDte.Debugger.CurrentMode == dbgDebugMode.dbgBreakMode
+                    ? HeartbeatCategory.Debugging 
+                    : HeartbeatCategory.Coding;
+
+                WakaTime.HandleActivity(document.FullName, false, GetProjectName(), category);
 
                 if (_isBuildRunning)
-                    WakaTime.HandleActivity(_runningBuildOutput, false, GetProjectName(), HeartbeatCategory.Building); //eventType defaults to "file"
+                    WakaTime.HandleActivity(_runningBuildOutput, false, GetProjectName(), HeartbeatCategory.Building);
             }
             catch (Exception ex)
             {
@@ -157,11 +159,14 @@ namespace WakaTime
         {
             try
             {
-                var activity = ObjDte.Debugger.CurrentMode == dbgDebugMode.dbgBreakMode ? HeartbeatCategory.Debugging : HeartbeatCategory.Coding;
-                WakaTime.HandleActivity(document.FullName, true, GetProjectName(), HeartbeatCategory.Debugging); //eventType defaults to "file"
+                var category = ObjDte.Debugger.CurrentMode == dbgDebugMode.dbgBreakMode
+                    ? HeartbeatCategory.Debugging
+                    : HeartbeatCategory.Coding;
+
+                WakaTime.HandleActivity(document.FullName, true, GetProjectName(), category);
 
                 if (_isBuildRunning)
-                    WakaTime.HandleActivity(_runningBuildOutput, false, GetProjectName(), HeartbeatCategory.Building); //eventType defaults to "file"
+                    WakaTime.HandleActivity(_runningBuildOutput, false, GetProjectName(), HeartbeatCategory.Building);
             }
             catch (Exception ex)
             {
@@ -173,12 +178,16 @@ namespace WakaTime
         {
             try
             {
-                var activity = ObjDte.Debugger.CurrentMode == dbgDebugMode.dbgBreakMode ? HeartbeatCategory.Debugging : HeartbeatCategory.Coding;
                 var document = ObjDte.ActiveWindow.Document;
+                var category = ObjDte.Debugger.CurrentMode == dbgDebugMode.dbgBreakMode
+                    ? HeartbeatCategory.Debugging
+                    : HeartbeatCategory.Coding;
+
                 if (document != null)
-                    WakaTime.HandleActivity(document.FullName, false, GetProjectName(), activity); //eventType defaults to "file"
+                    WakaTime.HandleActivity(document.FullName, false, GetProjectName(), category);
+
                 if (_isBuildRunning)
-                    WakaTime.HandleActivity(_runningBuildOutput, false, GetProjectName(), HeartbeatCategory.Building); //eventType defaults to "file"
+                    WakaTime.HandleActivity(_runningBuildOutput, false, GetProjectName(), HeartbeatCategory.Building);
             }
             catch (Exception ex)
             {
@@ -198,12 +207,12 @@ namespace WakaTime
             }
         }
 
-        private void DebuggerEventsOnEnterRunMode(dbgEventReason Reason)
+        private void DebuggerEventsOnEnterRunMode(dbgEventReason reason)
         {
             try
             {
-                var fullOutputName = GetCurrentProjectOutputForCurrentConfiguration();
-                WakaTime.HandleActivity(fullOutputName, false, GetProjectName(), HeartbeatCategory.Debugging); //eventType defaults to "file"
+                var outputFile = GetCurrentProjectOutputForCurrentConfiguration();
+                WakaTime.HandleActivity(outputFile, false, GetProjectName(), HeartbeatCategory.Debugging);
             }
             catch (Exception ex)
             {
@@ -211,12 +220,12 @@ namespace WakaTime
             }
         }
 
-        private void DebuggerEventsOnEnterDesignMode(dbgEventReason Reason)
+        private void DebuggerEventsOnEnterDesignMode(dbgEventReason reason)
         {
             try
             {
-                var fullOutputName = GetCurrentProjectOutputForCurrentConfiguration();
-                WakaTime.HandleActivity(fullOutputName, false, GetProjectName(), HeartbeatCategory.Debugging); //eventType defaults to "file"
+                var outputFile = GetCurrentProjectOutputForCurrentConfiguration();
+                WakaTime.HandleActivity(outputFile, false, GetProjectName(), HeartbeatCategory.Debugging);
             }
             catch (Exception ex)
             {
@@ -224,12 +233,12 @@ namespace WakaTime
             }
         }
 
-        private void DebuggerEventsOnEnterBreakMode(dbgEventReason Reason, ref dbgExecutionAction ExecutionAction)
+        private void DebuggerEventsOnEnterBreakMode(dbgEventReason reason, ref dbgExecutionAction executionAction)
         {
             try
             {
-                var fullOutputName = GetCurrentProjectOutputForCurrentConfiguration();
-                WakaTime.HandleActivity(fullOutputName, false, GetProjectName(), HeartbeatCategory.Debugging); //eventType defaults to "file"
+                var outputFile = GetCurrentProjectOutputForCurrentConfiguration();
+                WakaTime.HandleActivity(outputFile, false, GetProjectName(), HeartbeatCategory.Debugging);
             }
             catch (Exception ex)
             {
@@ -237,14 +246,14 @@ namespace WakaTime
             }
         }
 
-        private void BuildEventsOnBuildProjConfigBegin(string Project, string ProjectConfig, string Platform, string SolutionConfig)
+        private void BuildEventsOnBuildProjConfigBegin(string project, string projectConfig, string platform, string solutionConfig)
         {
             try
             {
                 _isBuildRunning = true;
-                var fullOutputName = GetProjectOutputForConfiguration(Project, Platform, ProjectConfig);
-                _runningBuildOutput = fullOutputName;
-                WakaTime.HandleActivity(fullOutputName, false, GetProjectName(), HeartbeatCategory.Building); //eventType defaults to "file"
+                var outputFile = GetProjectOutputForConfiguration(project, platform, projectConfig);
+                _runningBuildOutput = outputFile;
+                WakaTime.HandleActivity(outputFile, false, GetProjectName(), HeartbeatCategory.Building);
             }
             catch (Exception ex)
             {
@@ -252,13 +261,13 @@ namespace WakaTime
             }
         }
 
-        private void BuildEventsOnBuildProjConfigDone(string Project, string ProjectConfig, string Platform, string SolutionConfig, bool Success)
+        private void BuildEventsOnBuildProjConfigDone(string project, string projectConfig, string platform, string solutionConfig, bool success)
         {
             try
             {
                 _isBuildRunning = false;
-                var fullOutputName = GetProjectOutputForConfiguration(Project, Platform, ProjectConfig);
-                WakaTime.HandleActivity(fullOutputName, Success, GetProjectName(), HeartbeatCategory.Building); //eventType defaults to "file"
+                var outputFile = GetProjectOutputForConfiguration(project, platform, projectConfig);
+                WakaTime.HandleActivity(outputFile, success, GetProjectName(), HeartbeatCategory.Building);
             }
             catch (Exception ex)
             {
@@ -266,18 +275,21 @@ namespace WakaTime
             }
         }
 
-        private void TextEditorEventsLineChanged(TextPoint StartPoint, TextPoint EndPoint, int Hint)
+        private void TextEditorEventsLineChanged(TextPoint startPoint, TextPoint endPoint, int hint)
         {
             try
             {
-                var document = StartPoint.Parent.Parent;
+                var document = startPoint.Parent.Parent;
                 if (document != null)
                 {
-                    var activity = ObjDte.Debugger.CurrentMode == dbgDebugMode.dbgBreakMode ? HeartbeatCategory.Debugging : HeartbeatCategory.Coding;
-                    WakaTime.HandleActivity(document.FullName, false, GetProjectName(), activity); //eventType defaults to "file"
+                    var category = ObjDte.Debugger.CurrentMode == dbgDebugMode.dbgBreakMode
+                        ? HeartbeatCategory.Debugging
+                        : HeartbeatCategory.Coding;
+
+                    WakaTime.HandleActivity(document.FullName, false, GetProjectName(), category);
 
                     if (_isBuildRunning)
-                        WakaTime.HandleActivity(_runningBuildOutput, false, GetProjectName(), HeartbeatCategory.Building); //eventType defaults to "file"
+                        WakaTime.HandleActivity(_runningBuildOutput, false, GetProjectName(), HeartbeatCategory.Building);
                 }
             }
             catch (Exception ex)
@@ -334,26 +346,47 @@ namespace WakaTime
                     : string.Empty;
         }
 
-        private string GetProjectOutputForConfiguration(string Project, string Platform, string ProjectConfig)
+        private static string GetProjectOutputForConfiguration(string projectName, string platform, string projectConfig)
         {
-            var project = ObjDte.Solution.Projects.Cast<Project>().Where(proj => proj.UniqueName == Project).FirstOrDefault();
-            var config = project.ConfigurationManager.Cast<EnvDTE.Configuration>().Where(conf => conf.PlatformName == Platform && conf.ConfigurationName == ProjectConfig).FirstOrDefault();
-            var outputPath = config.Properties.Item("OutputPath");
-            var outputFileName = project.Properties.Item("OutputFileName");
-            var projectPath = project.Properties.Item("FullPath");
+            try
+            {
+                var project = ObjDte.Solution.Projects.Cast<Project>()
+                                .FirstOrDefault(proj => proj.UniqueName == projectName);
 
-            return $"{projectPath.Value}{outputPath.Value}{outputFileName.Value}";
+                var config = project.ConfigurationManager.Cast<EnvDTE.Configuration>()
+                                .FirstOrDefault(conf => conf.PlatformName == platform && conf.ConfigurationName == projectConfig);
+
+                var outputPath = config.Properties.Item("OutputPath");
+                var outputFileName = project.Properties.Item("OutputFileName");
+                var projectPath = project.Properties.Item("FullPath");
+
+                return $"{projectPath.Value}{outputPath.Value}{outputFileName.Value}";
+            }
+            catch(Exception)
+            {
+                return null;
+            }
         }
 
-        private string GetCurrentProjectOutputForCurrentConfiguration()
+        private static string GetCurrentProjectOutputForCurrentConfiguration()
         {
-            var project = (Project)((object[])ObjDte.ActiveSolutionProjects)[0];
-            var config = project.ConfigurationManager.ActiveConfiguration;
-            var outputPath = config.Properties.Item("OutputPath");
-            var outputFileName = project.Properties.Item("OutputFileName");
-            var projectPath = project.Properties.Item("FullPath");
+            try
+            {
+                var activeProjects = (object[])ObjDte.ActiveSolutionProjects;
+                if (ObjDte.Solution == null || activeProjects.Length < 1)
+                    return null;
+                var project = (Project)((object[])ObjDte.ActiveSolutionProjects)[0];
+                var config = project.ConfigurationManager.ActiveConfiguration;
+                var outputPath = config.Properties.Item("OutputPath");
+                var outputFileName = project.Properties.Item("OutputFileName");
+                var projectPath = project.Properties.Item("FullPath");
 
-            return $"{projectPath.Value}{outputPath.Value}{outputFileName.Value}";
+                return $"{projectPath.Value}{outputPath.Value}{outputFileName.Value}";
+            }
+            catch(Exception)
+            {
+                return null;
+            }
         }
 
         protected override void Dispose(bool disposing)

--- a/WakaTime/WakaTimePackage.cs
+++ b/WakaTime/WakaTimePackage.cs
@@ -113,7 +113,7 @@ namespace WakaTime
                     mcs.AddCommand(menuItem);
                 }
 
-                // setup event handlers                
+                // setup event handlers
                 _docEvents.DocumentOpened += DocEventsOnDocumentOpened;
                 _docEvents.DocumentSaved += DocEventsOnDocumentSaved;
                 _windowEvents.WindowActivated += WindowEventsOnWindowActivated;
@@ -211,6 +211,7 @@ namespace WakaTime
             try
             {
                 var outputFile = GetCurrentProjectOutputForCurrentConfiguration();
+
                 WakaTime.HandleActivity(outputFile, false, GetProjectName(), HeartbeatCategory.Debugging);
             }
             catch (Exception ex)
@@ -224,6 +225,7 @@ namespace WakaTime
             try
             {
                 var outputFile = GetCurrentProjectOutputForCurrentConfiguration();
+
                 WakaTime.HandleActivity(outputFile, false, GetProjectName(), HeartbeatCategory.Debugging);
             }
             catch (Exception ex)
@@ -237,6 +239,7 @@ namespace WakaTime
             try
             {
                 var outputFile = GetCurrentProjectOutputForCurrentConfiguration();
+
                 WakaTime.HandleActivity(outputFile, false, GetProjectName(), HeartbeatCategory.Debugging);
             }
             catch (Exception ex)
@@ -250,8 +253,11 @@ namespace WakaTime
             try
             {
                 _isBuildRunning = true;
+
                 var outputFile = GetProjectOutputForConfiguration(project, platform, projectConfig);
+
                 _runningBuildOutput = outputFile;
+
                 WakaTime.HandleActivity(outputFile, false, GetProjectName(), HeartbeatCategory.Building);
             }
             catch (Exception ex)
@@ -265,7 +271,9 @@ namespace WakaTime
             try
             {
                 _isBuildRunning = false;
+
                 var outputFile = GetProjectOutputForConfiguration(project, platform, projectConfig);
+
                 WakaTime.HandleActivity(outputFile, success, GetProjectName(), HeartbeatCategory.Building);
             }
             catch (Exception ex)
@@ -279,6 +287,7 @@ namespace WakaTime
             try
             {
                 var document = startPoint.Parent.Parent;
+
                 if (document != null)
                 {
                     var category = _isBuildRunning
@@ -373,6 +382,7 @@ namespace WakaTime
                 var activeProjects = (object[])ObjDte.ActiveSolutionProjects;
                 if (ObjDte.Solution == null || activeProjects.Length < 1)
                     return null;
+
                 var project = (Project)((object[])ObjDte.ActiveSolutionProjects)[0];
                 var config = project.ConfigurationManager.ActiveConfiguration;
                 var outputPath = config.Properties.Item("OutputPath");

--- a/WakaTime/WakaTimePackage.cs
+++ b/WakaTime/WakaTimePackage.cs
@@ -33,6 +33,9 @@ namespace WakaTime
         private BuildEvents _buildEvents;
         private TextEditorEvents _textEditorEvents;
 
+        private bool _isBuildRunning = false;
+        private string _runningBuildOutput;
+
         public static DTE ObjDte;
 
         private static string _solutionName = string.Empty;
@@ -140,6 +143,9 @@ namespace WakaTime
             {
                 var activity = ObjDte.Debugger.CurrentMode == dbgDebugMode.dbgBreakMode ? HeartbeatCategory.debugging : HeartbeatCategory.coding;
                 WakaTime.HandleActivity(document.FullName, false, GetProjectName(), activity); //eventType defaults to "file"
+
+                if (_isBuildRunning)
+                    WakaTime.HandleActivity(_runningBuildOutput, false, GetProjectName(), HeartbeatCategory.building); //eventType defaults to "file"
             }
             catch (Exception ex)
             {
@@ -153,6 +159,9 @@ namespace WakaTime
             {
                 var activity = ObjDte.Debugger.CurrentMode == dbgDebugMode.dbgBreakMode ? HeartbeatCategory.debugging : HeartbeatCategory.coding;
                 WakaTime.HandleActivity(document.FullName, true, GetProjectName(), HeartbeatCategory.debugging); //eventType defaults to "file"
+
+                if (_isBuildRunning)
+                    WakaTime.HandleActivity(_runningBuildOutput, false, GetProjectName(), HeartbeatCategory.building); //eventType defaults to "file"
             }
             catch (Exception ex)
             {
@@ -168,6 +177,8 @@ namespace WakaTime
                 var document = ObjDte.ActiveWindow.Document;
                 if (document != null)
                     WakaTime.HandleActivity(document.FullName, false, GetProjectName(), activity); //eventType defaults to "file"
+                if (_isBuildRunning)
+                    WakaTime.HandleActivity(_runningBuildOutput, false, GetProjectName(), HeartbeatCategory.building); //eventType defaults to "file"
             }
             catch (Exception ex)
             {
@@ -230,7 +241,9 @@ namespace WakaTime
         {
             try
             {
+                _isBuildRunning = true;
                 var fullOutputName = GetProjectOutputForConfiguration(Project, Platform, ProjectConfig);
+                _runningBuildOutput = fullOutputName;
                 WakaTime.HandleActivity(fullOutputName, false, GetProjectName(), HeartbeatCategory.building); //eventType defaults to "file"
             }
             catch (Exception ex)
@@ -243,6 +256,7 @@ namespace WakaTime
         {
             try
             {
+                _isBuildRunning = false;
                 var fullOutputName = GetProjectOutputForConfiguration(Project, Platform, ProjectConfig);
                 WakaTime.HandleActivity(fullOutputName, Success, GetProjectName(), HeartbeatCategory.building); //eventType defaults to "file"
             }
@@ -260,7 +274,10 @@ namespace WakaTime
                 if (document != null)
                 {
                     var activity = ObjDte.Debugger.CurrentMode == dbgDebugMode.dbgBreakMode ? HeartbeatCategory.debugging : HeartbeatCategory.coding;
-                    WakaTime.HandleActivity(document.FullName, false, GetProjectName(), activity);
+                    WakaTime.HandleActivity(document.FullName, false, GetProjectName(), activity); //eventType defaults to "file"
+
+                    if (_isBuildRunning)
+                        WakaTime.HandleActivity(_runningBuildOutput, false, GetProjectName(), HeartbeatCategory.building); //eventType defaults to "file"
                 }
             }
             catch (Exception ex)

--- a/WakaTime/WakaTimePackage.cs
+++ b/WakaTime/WakaTimePackage.cs
@@ -140,14 +140,13 @@ namespace WakaTime
         {
             try
             {
-                var category = ObjDte.Debugger.CurrentMode == dbgDebugMode.dbgBreakMode
-                    ? HeartbeatCategory.Debugging 
-                    : HeartbeatCategory.Coding;
+                var category = _isBuildRunning
+                        ? HeartbeatCategory.Building
+                        : ObjDte.Debugger.CurrentMode == dbgDebugMode.dbgBreakMode
+                            ? HeartbeatCategory.Debugging
+                            : HeartbeatCategory.Coding;
 
                 WakaTime.HandleActivity(document.FullName, false, GetProjectName(), category);
-
-                if (_isBuildRunning)
-                    WakaTime.HandleActivity(_runningBuildOutput, false, GetProjectName(), HeartbeatCategory.Building);
             }
             catch (Exception ex)
             {
@@ -159,14 +158,13 @@ namespace WakaTime
         {
             try
             {
-                var category = ObjDte.Debugger.CurrentMode == dbgDebugMode.dbgBreakMode
-                    ? HeartbeatCategory.Debugging
-                    : HeartbeatCategory.Coding;
+                var category = _isBuildRunning
+                        ? HeartbeatCategory.Building
+                        : ObjDte.Debugger.CurrentMode == dbgDebugMode.dbgBreakMode
+                            ? HeartbeatCategory.Debugging
+                            : HeartbeatCategory.Coding;
 
                 WakaTime.HandleActivity(document.FullName, true, GetProjectName(), category);
-
-                if (_isBuildRunning)
-                    WakaTime.HandleActivity(_runningBuildOutput, false, GetProjectName(), HeartbeatCategory.Building);
             }
             catch (Exception ex)
             {
@@ -179,15 +177,16 @@ namespace WakaTime
             try
             {
                 var document = ObjDte.ActiveWindow.Document;
-                var category = ObjDte.Debugger.CurrentMode == dbgDebugMode.dbgBreakMode
-                    ? HeartbeatCategory.Debugging
-                    : HeartbeatCategory.Coding;
-
                 if (document != null)
-                    WakaTime.HandleActivity(document.FullName, false, GetProjectName(), category);
+                {
+                    var category = _isBuildRunning
+                        ? HeartbeatCategory.Building
+                        : ObjDte.Debugger.CurrentMode == dbgDebugMode.dbgBreakMode
+                            ? HeartbeatCategory.Debugging
+                            : HeartbeatCategory.Coding;
 
-                if (_isBuildRunning)
-                    WakaTime.HandleActivity(_runningBuildOutput, false, GetProjectName(), HeartbeatCategory.Building);
+                    WakaTime.HandleActivity(document.FullName, false, GetProjectName(), category);
+                }
             }
             catch (Exception ex)
             {
@@ -282,14 +281,13 @@ namespace WakaTime
                 var document = startPoint.Parent.Parent;
                 if (document != null)
                 {
-                    var category = ObjDte.Debugger.CurrentMode == dbgDebugMode.dbgBreakMode
-                        ? HeartbeatCategory.Debugging
-                        : HeartbeatCategory.Coding;
+                    var category = _isBuildRunning
+                        ? HeartbeatCategory.Building
+                        : ObjDte.Debugger.CurrentMode == dbgDebugMode.dbgBreakMode
+                            ? HeartbeatCategory.Debugging
+                            : HeartbeatCategory.Coding;
 
                     WakaTime.HandleActivity(document.FullName, false, GetProjectName(), category);
-
-                    if (_isBuildRunning)
-                        WakaTime.HandleActivity(_runningBuildOutput, false, GetProjectName(), HeartbeatCategory.Building);
                 }
             }
             catch (Exception ex)

--- a/WakaTime/WakaTimePackage.cs
+++ b/WakaTime/WakaTimePackage.cs
@@ -141,11 +141,11 @@ namespace WakaTime
         {
             try
             {
-                var activity = ObjDte.Debugger.CurrentMode == dbgDebugMode.dbgBreakMode ? HeartbeatCategory.debugging : HeartbeatCategory.coding;
+                var activity = ObjDte.Debugger.CurrentMode == dbgDebugMode.dbgBreakMode ? HeartbeatCategory.Debugging : HeartbeatCategory.Coding;
                 WakaTime.HandleActivity(document.FullName, false, GetProjectName(), activity); //eventType defaults to "file"
 
                 if (_isBuildRunning)
-                    WakaTime.HandleActivity(_runningBuildOutput, false, GetProjectName(), HeartbeatCategory.building); //eventType defaults to "file"
+                    WakaTime.HandleActivity(_runningBuildOutput, false, GetProjectName(), HeartbeatCategory.Building); //eventType defaults to "file"
             }
             catch (Exception ex)
             {
@@ -157,11 +157,11 @@ namespace WakaTime
         {
             try
             {
-                var activity = ObjDte.Debugger.CurrentMode == dbgDebugMode.dbgBreakMode ? HeartbeatCategory.debugging : HeartbeatCategory.coding;
-                WakaTime.HandleActivity(document.FullName, true, GetProjectName(), HeartbeatCategory.debugging); //eventType defaults to "file"
+                var activity = ObjDte.Debugger.CurrentMode == dbgDebugMode.dbgBreakMode ? HeartbeatCategory.Debugging : HeartbeatCategory.Coding;
+                WakaTime.HandleActivity(document.FullName, true, GetProjectName(), HeartbeatCategory.Debugging); //eventType defaults to "file"
 
                 if (_isBuildRunning)
-                    WakaTime.HandleActivity(_runningBuildOutput, false, GetProjectName(), HeartbeatCategory.building); //eventType defaults to "file"
+                    WakaTime.HandleActivity(_runningBuildOutput, false, GetProjectName(), HeartbeatCategory.Building); //eventType defaults to "file"
             }
             catch (Exception ex)
             {
@@ -173,12 +173,12 @@ namespace WakaTime
         {
             try
             {
-                var activity = ObjDte.Debugger.CurrentMode == dbgDebugMode.dbgBreakMode ? HeartbeatCategory.debugging : HeartbeatCategory.coding;
+                var activity = ObjDte.Debugger.CurrentMode == dbgDebugMode.dbgBreakMode ? HeartbeatCategory.Debugging : HeartbeatCategory.Coding;
                 var document = ObjDte.ActiveWindow.Document;
                 if (document != null)
                     WakaTime.HandleActivity(document.FullName, false, GetProjectName(), activity); //eventType defaults to "file"
                 if (_isBuildRunning)
-                    WakaTime.HandleActivity(_runningBuildOutput, false, GetProjectName(), HeartbeatCategory.building); //eventType defaults to "file"
+                    WakaTime.HandleActivity(_runningBuildOutput, false, GetProjectName(), HeartbeatCategory.Building); //eventType defaults to "file"
             }
             catch (Exception ex)
             {
@@ -203,7 +203,7 @@ namespace WakaTime
             try
             {
                 var fullOutputName = GetCurrentProjectOutputForCurrentConfiguration();
-                WakaTime.HandleActivity(fullOutputName, false, GetProjectName(), HeartbeatCategory.debugging); //eventType defaults to "file"
+                WakaTime.HandleActivity(fullOutputName, false, GetProjectName(), HeartbeatCategory.Debugging); //eventType defaults to "file"
             }
             catch (Exception ex)
             {
@@ -216,7 +216,7 @@ namespace WakaTime
             try
             {
                 var fullOutputName = GetCurrentProjectOutputForCurrentConfiguration();
-                WakaTime.HandleActivity(fullOutputName, false, GetProjectName(), HeartbeatCategory.debugging); //eventType defaults to "file"
+                WakaTime.HandleActivity(fullOutputName, false, GetProjectName(), HeartbeatCategory.Debugging); //eventType defaults to "file"
             }
             catch (Exception ex)
             {
@@ -229,7 +229,7 @@ namespace WakaTime
             try
             {
                 var fullOutputName = GetCurrentProjectOutputForCurrentConfiguration();
-                WakaTime.HandleActivity(fullOutputName, false, GetProjectName(), HeartbeatCategory.debugging); //eventType defaults to "file"
+                WakaTime.HandleActivity(fullOutputName, false, GetProjectName(), HeartbeatCategory.Debugging); //eventType defaults to "file"
             }
             catch (Exception ex)
             {
@@ -244,7 +244,7 @@ namespace WakaTime
                 _isBuildRunning = true;
                 var fullOutputName = GetProjectOutputForConfiguration(Project, Platform, ProjectConfig);
                 _runningBuildOutput = fullOutputName;
-                WakaTime.HandleActivity(fullOutputName, false, GetProjectName(), HeartbeatCategory.building); //eventType defaults to "file"
+                WakaTime.HandleActivity(fullOutputName, false, GetProjectName(), HeartbeatCategory.Building); //eventType defaults to "file"
             }
             catch (Exception ex)
             {
@@ -258,7 +258,7 @@ namespace WakaTime
             {
                 _isBuildRunning = false;
                 var fullOutputName = GetProjectOutputForConfiguration(Project, Platform, ProjectConfig);
-                WakaTime.HandleActivity(fullOutputName, Success, GetProjectName(), HeartbeatCategory.building); //eventType defaults to "file"
+                WakaTime.HandleActivity(fullOutputName, Success, GetProjectName(), HeartbeatCategory.Building); //eventType defaults to "file"
             }
             catch (Exception ex)
             {
@@ -273,11 +273,11 @@ namespace WakaTime
                 var document = StartPoint.Parent.Parent;
                 if (document != null)
                 {
-                    var activity = ObjDte.Debugger.CurrentMode == dbgDebugMode.dbgBreakMode ? HeartbeatCategory.debugging : HeartbeatCategory.coding;
+                    var activity = ObjDte.Debugger.CurrentMode == dbgDebugMode.dbgBreakMode ? HeartbeatCategory.Debugging : HeartbeatCategory.Coding;
                     WakaTime.HandleActivity(document.FullName, false, GetProjectName(), activity); //eventType defaults to "file"
 
                     if (_isBuildRunning)
-                        WakaTime.HandleActivity(_runningBuildOutput, false, GetProjectName(), HeartbeatCategory.building); //eventType defaults to "file"
+                        WakaTime.HandleActivity(_runningBuildOutput, false, GetProjectName(), HeartbeatCategory.Building); //eventType defaults to "file"
                 }
             }
             catch (Exception ex)

--- a/WakaTime/packages.config
+++ b/WakaTime/packages.config
@@ -22,5 +22,5 @@
   <package id="Microsoft.VisualStudio.Validation" version="14.1.111" targetFramework="net48" />
   <package id="VSSDK.DTE" version="7.0.4" targetFramework="net48" />
   <package id="VSSDK.IDE" version="7.0.4" targetFramework="net48" />
-  <package id="WakaTime.Shared.ExtensionUtils" version="2.0.0" targetFramework="net48" />
+  <package id="WakaTime.Shared.ExtensionUtils" version="2.2.0" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
Enhancements proposed on wakatime/visualstudio-wakatime#106

### Note on .csproj reference:
I had to remove the original reference so the signed extension utils dll and replace with a reference to my locally built file. I will obviously not gonna commit the .csproj file with the reference change, which means this code **will only run** with the original reference once the pull request wakatime/nuget-wakatime-shared-extension-utils#3 has been merged and the binary rebuilt.

# The IDE Events

The plugin can now respond to new IDE events:
- Debugging [`DebuggerEvents`]
    - `OnEnterRunMode`
    - `OnEnterBreakMode`
    - `OnEnterDesignMode`
- Building [`BuildEvents`]
    - `OnBuildProjConfigBegin`
    - `OnBuildProjConfigDone`
- Coding [`TextEditorEvents`]
    - `LineChanged`

Previously Implemented and updated:
- Coding
    - [`DocumentEvents`]
        - `DocumentOpened`
        - `DocumentSaved`
    - [`WindowEvents`]
        - `WindowActivated`

Events not issuing heartbeats:
- [`SolutionEvents`]
    - `Opened`

## Heartbeat and Event Categories

The event's holding class categorizes the event type, and therefore the heartbeat category is closely related to it:

- DebuggerEvents:
    - All events issued are related to the debug flow, and are **NOT** triggered by file changes.
    - These events will issue heartbeat indicating the _debugging_ activity, with the actual debugging project's output file full name. 
    - File change related events will monitor the debugger mode to change the file action accordingly.
- BuildEvents:
    - These events are raised when build begins and ends only.
    - File changed events will monitor if an ongoing build exists so they can continue to issue heartbeats for the project's "building" activity.
- DocumentEvents & TextEditorEvents
    - These events are used to detect changes made to the files.
    - The `LineChanged` event will bring the plugin in accordance to the guidelines on [Creating a Plugin: Handling Editor Events](https://wakatime.com/help/creating-plugin#handling-editor-events)

## Heartbeat Setups

Below we will go over how each event will setup a heartbeat through the `WakaTime.HandleActivity` method:

> **Remark**
> The "Project" parameter is common to all events: `GetProjectName()`.

### The new events:

- Debugging [`DebuggerEvents`]
    - `OnEnterRunMode`
        - Entity: (ProjectOutput) (the solution's current start-up project) [1]
        - IsWrite: False
        - Category: "debugging"
        - EntityType: "file"
    - `OnEnterBreakMode`
        - Entity: (ProjectOutput) (the solution's current start-up project) [1]
        - IsWrite: False
        - Category: "debugging"
        - EntityType: "file"
    - `OnEnterDesignMode`
        - Entity: (ProjectOutput)  (the solution's current start-up project) [1]
        - IsWrite: False
        - Category: "debugging"
        - EntityType: "file"
- Building [`BuildEvents`]
    - `OnBuildProjConfigBegin`
        - Entity: (ProjectOutput)  (as supplied by event argument) [2]
        - IsWrite: False
        - Category: "building"
        - EntityType: "file"
    - `OnBuildProjConfigDone`
        - Entity: (ProjectOutput)  (as supplied by event argument) [2]
        - IsWrite: True/False  (according to the `Success` event argument) [3]
        - Category: "building"
        - EntityType: "file"
- Coding [`TextEditorEvents`]
    - `LineChanged`
        - Heartbeat 1
            - Entity: (ChangedDocument) (as supplied by event argument) [2]
            - IsWrite: False
            - Category:
                - Debugger in Break mode: "debugging"
                - Debugger in Run or Design mode: "coding"
            - EntityType: "file"
        - Heartbeat 2 (if a build is in progress)
            - Entity: (ProjectOutput) (for currently building project, not the currently focused one) [4]
            - IsWrite: False
            - Category: "building"
            - EntityType: "file"

### Previously implemented updated events:

- Coding
    - [`DocumentEvents`]
        - `DocumentOpened`
            - Heartbeat 1
                - Entity: (OpenedDocument) (as suplied by event argument) [2]
                - IsWrite: False
                - Category:
                    - Debugger in Break mode: "debugging"
                    - Debugger in Run or Design mode: "coding"
                - EntityType: "file"
            - Heartbeat 2 (if a build is in progress)
                - Entity: (ProjectOutput) (for currently building project, not the currently focused one) [4]
                - IsWrite: False
                - Category: "building"
                - EntityType: "file"
        - `DocumentSaved`
            - Heartbeat 1
                - Entity: (SavedDocument) (as supplied by event argument) [2]
                - IsWrite: True
                - Category:
                    - Debugger in Break mode: "debugging"
                    - Debugger in Run or Design mode: "coding"
                - EntityType: "file"
            - Heartbeat 2 (if a build is in progress)
                - Entity: (ProjectOutput) (for currently building project, not the currently focused one) [4]
                - IsWrite: False
                - Category: "building"
                - EntityType: "file"
    - [`WindowEvents`]
        - `WindowActivated`
            - Heartbeat 1
                - Entity: (ActivatedWindowDocument) (as supplied by event argument) [2]
                - IsWrite: False
                - Category:
                    - Debugger in Break mode: "debugging"
                    - Debugger in Run or Design mode: "coding"
                - EntityType: "file"
            - Heartbeat 2 (if a build is in progress)
                - Entity: (ProjectOutput) (for currently building project, not the currently focused one) [4]
                - IsWrite: False
                - Category: "building"
                - EntityType: "file"

> **Notes**:
>**[1]** *(the solution's current start-up project)*: When the debugger begins, it locks the solution settings such that the start-up project can't be changed. This will always retrieve the actual project currently being debugged.
> **[2]** *(as supplied by event argument)*: Parameters that come from the events arguments ensure they will be correct in the unlikely event that the solution settings change between the invocation of the event and a possible attempt to get the current COM object (whether it's a Document, Project, etc).
> **[3]** *(according to the `Success` event argument)*: Only when the build is successful the project output file is actually written to, overwriting the previous successful build.
> **[4]** *(for currently building project, not the currently focused one)*: When the build begins, it stores the output file for the project supplied by the event, ensuring we won't mis-read the building project if the active project changes during an ongoing build.

## Results
As I was debugging the plugin I created a new project and spent very little time on it. As a Visual Studio user, this is the first time I see the "activity" panel display other activities (and other colours).
![image](https://user-images.githubusercontent.com/23237569/91906212-2f310e80-ec7e-11ea-85b9-88a410ff9e8d.png)
